### PR TITLE
get_inventory_worth patch

### DIFF
--- a/steam_web_api.py
+++ b/steam_web_api.py
@@ -65,7 +65,7 @@ class SteamWebApi:
         inventory = response.json()
 
         return {
-            'worth': sum(float(item['priceAvg']) for item in inventory),
+            'worth': sum(float(item['priceavg']) for item in inventory),
             'inventory': inventory
         }
 


### PR DESCRIPTION
Patched get_inventory_worth, the api returns a key called "priceavg", not "priceAvg".